### PR TITLE
CSS fixes for header and flash

### DIFF
--- a/app/assets/stylesheets/application/common/_header.scss
+++ b/app/assets/stylesheets/application/common/_header.scss
@@ -1,0 +1,3 @@
+.navbar {
+  margin: 0;
+}

--- a/app/assets/stylesheets/application/common/_top_container.scss
+++ b/app/assets/stylesheets/application/common/_top_container.scss
@@ -1,0 +1,1 @@
+.container-top { margin-top: 20px; }

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,5 +1,7 @@
 class Admin::BaseController < ApplicationController
 
+  before_action :authenticate_admin!
+
   layout 'admin'
 
 end

--- a/app/views/admins/sessions/new.html.slim
+++ b/app/views/admins/sessions/new.html.slim
@@ -1,4 +1,4 @@
-.container
+.container.container-top
   .row
     .col-md-8.col-md-offset-2
 


### PR DESCRIPTION
This PR implements some CSS fixes by removing `margin-bottom: 20px;` from navbars and putting `margin-top: 20px;` to all `.container-top` classes instead.